### PR TITLE
chore: group renovate updates for tokio and serde

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,27 @@
     ":automergeLinters",
     ":automergeTypes",
     ":automergeMinor"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Rust tokio family",
+      "matchDatasources": [
+        "crate"
+      ],
+      "matchPackageNames": [
+        "axum",
+        "tokio",
+        "tower-http"
+      ]
+    },
+    {
+      "groupName": "Rust serde",
+      "matchDatasources": [
+        "crate"
+      ],
+      "matchPackageNames": [
+        "serde*"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
The tokio family of packages often needs to update together as does the serde packages so update them as a group.